### PR TITLE
Rewritten draft

### DIFF
--- a/draft-wuertele-oauth-security-topics-update.md
+++ b/draft-wuertele-oauth-security-topics-update.md
@@ -489,7 +489,7 @@ Unlike what expected in {{Section 4.4 of !RFC9700}}, an authorization server (or
 - in addition to the above, a platform's client allowing multiple OAuth providers for a tool SHOULD include identifiers that represent the tool and the OAuth provider.
 - in addition to the above, an OAuth-as-a-service managed client MUST include identifiers that represent the tenant, tool and OAuth provider.
 
-The client MUST issues redirection URI that incorporates this unique connection context identifier. When initiating an authorization request, the client MUST store this identifier in the user's session. When an authorization response was received on the redirection URI endpoint, Clients MUST also check that a context identifier matches with the one in the distinct redirection URI. If there is a mismatch, the client MUST abort the flow.
+The client MUST issue distinct redirection URI that incorporates this unique connection context identifier. When initiating an authorization request, the client MUST store this identifier in the user's session. When an authorization response was received on the redirection URI endpoint, Clients MUST also check that a context identifier matches with the one in the distinct redirection URI. If there is a mismatch, the client MUST abort the flow.
 
 ## Session Fixation {#SessionFixation}
 Session fixation attacks can occur when the client relies on an authorization session fixated through a URL, instead of the existing user-agent session, to identify the user at the redirection endpoint.


### PR DESCRIPTION
@KevinLuo2000 

I think the way I squeeze and generalize the texts can have a single section cover:
- cross-tenant COAT. can be further elaborated as a variant that violates the connection context id. should add a line that openness to one tenant can impact another tenant that use only a handpicked and limited honest auth providers.
- shared client id attacks by arcade, can be further elaborated as a variant that shares tool and auth provider (oauth credentials included) between tenant
- and basically everything except the "client configuration confusion attack" (which I removed for now, and hope to rename it as "resource server confusion attack". I dont think it will help us push it as WG draft, nor have a real attack mapped to it, so may be it should just appear in a later version.)

also tried to use the terminologies like connections. 